### PR TITLE
Change destination directory for TextMate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ TextMate Bundle for RubyMotion
 ## Installation
 
 ```shell
-cd ~/Library/Application Support/Avian/Bundles
+cd ~/Library/Application\ Support/TextMate/Bundles
 git clone git://github.com/libin/RubyMotion.tmbundle.git
 ```


### PR DESCRIPTION
README contains an error in the destination directory for the TextMate Bundle
