### PR TITLE
Add instructions for TextMate 2 Bundle folder location

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ TextMate Bundle for RubyMotion
 cd ~/Library/Application\ Support/TextMate/Bundles
 git clone git://github.com/libin/RubyMotion.tmbundle.git
 ```
+
+### TextMate 2.0
+```shell
+cd ~/Library/Application\ Support/Avian/Bundles
+git clone git://github.com/libin/RubyMotion.tmbundle.git
+```


### PR DESCRIPTION
Added a couple of lines to make it easier to include the bundle in TextMate 2 
